### PR TITLE
Update app block example to use the latest image_url filter

### DIFF
--- a/blocks/app-block.liquid
+++ b/blocks/app-block.liquid
@@ -10,28 +10,28 @@
   <div class="gallery">
     <figure class="gallery__item gallery__item--1">
       {%- if block.settings.image_1 -%}
-        <img src="{{ block.settings.image_1 | img_url: '1024x' }}" alt="{{ block.settings.image_1.alt }}" loading="lazy" width="{{block.settings.image_1.width}}" height="{{block.settings.image_1.height}}">
+        <img src="{{ block.settings.image_1 | image_url: width: 1024 }}" alt="{{ block.settings.image_1.alt }}" loading="lazy" width="{{ block.settings.image_1.width }}" height="{{ block.settings.image_1.height }}">
       {%- else -%}
         <img src="{{ 'party-hat-frenchie.jpg' | asset_url }}" loading="lazy" width="925" height="617">
       {%- endif -%}
     </figure>
     <figure class="gallery__item gallery__item--2">
       {%- if block.settings.image_2 -%}
-        <img src="{{ block.settings.image_2 | img_url: '1024x' }}" alt="{{ block.settings.image_2.alt }}" loading="lazy" width="{{block.settings.image_2.width}}" height="{{block.settings.image_2.height}}">
+        <img src="{{ block.settings.image_2 | image_url: width: 1024 }}" alt="{{ block.settings.image_2.alt }}" loading="lazy" width="{{ block.settings.image_2.width }}" height="{{ block.settings.image_2.height }}">
       {%- else -%}
         <img src="{{ 'dog-in-birthday-hat.jpg' | asset_url }}" loading="lazy" width="925" height="617">
       {%- endif -%}
     </figure>
     <figure class="gallery__item gallery__item--3">
       {%- if block.settings.image_3 -%}
-        <img src="{{ block.settings.image_3 | img_url: '1024x'}}" alt="{{ block.settings.image_3.alt }}" loading="lazy" width="{{block.settings.image_3.width}}" height="{{block.settings.image_3.height}}">
+        <img src="{{ block.settings.image_3 | image_url: width: 1024 }}" alt="{{ block.settings.image_3.alt }}" loading="lazy" width="{{ block.settings.image_3.width }}" height="{{ block.settings.image_3.height }}">
       {%- else -%}
         <img src="{{ 'all-dogs-go-to-birthday.jpg' | asset_url }}" loading="lazy" width="925" height="921">
       {%- endif -%}
     </figure>
     <figure class="gallery__item gallery__item--4">
       {%- if block.settings.image_4 -%}
-        <img src="{{ block.settings.image_4 | img_url: '1024x' }}" alt="{{ block.settings.image_4.alt }}" loading="lazy" width="{{block.settings.image_4.width}}" height="{{block.settings.image_4.height}}">
+        <img src="{{ block.settings.image_4 | image_url: width: 1024 }}" alt="{{ block.settings.image_4.alt }}" loading="lazy" width="{{ block.settings.image_4.width }}" height="{{ block.settings.image_4.height }}">
       {%- else -%}
         <img src="{{ 'poochie-party-treats.jpg' | asset_url }}" loading="lazy" width="925" height="617">
       {%- endif -%}


### PR DESCRIPTION
The example PR contained numerous `theme-check` errors. The updates here address all of them

```
➜  theme-app-extension shopify extension check
Checking . ...
blocks/app-block.liquid:13: style: SpaceInsideBraces: Space missing after '{{'.
	<img src="{{ block.settings.image_1 | img_url: '1024x' }}" alt="{{ block.settings.image_1.alt }}" loading="lazy" widt...
	             ^

blocks/app-block.liquid:13: style: SpaceInsideBraces: Space missing before '}}'.
	<img src="{{ block.settings.image_1 | img_url: '1024x' }}" alt="{{ block.settings.image_1.alt }}" loading="lazy" widt...

blocks/app-block.liquid:13: style: SpaceInsideBraces: Space missing after '{{'.
	<img src="{{ block.settings.image_1 | img_url: '1024x' }}" alt="{{ block.settings.image_1.alt }}" loading="lazy" widt...
	             ^

blocks/app-block.liquid:13: style: SpaceInsideBraces: Space missing before '}}'.
	<img src="{{ block.settings.image_1 | img_url: '1024x' }}" alt="{{ block.settings.image_1.alt }}" loading="lazy" widt...
	                     ^

blocks/app-block.liquid:20: style: SpaceInsideBraces: Space missing after '{{'.
	<img src="{{ block.settings.image_2 | img_url: '1024x' }}" alt="{{ block.settings.image_2.alt }}" loading="lazy" widt...
	             ^

blocks/app-block.liquid:20: style: SpaceInsideBraces: Space missing before '}}'.
	<img src="{{ block.settings.image_2 | img_url: '1024x' }}" alt="{{ block.settings.image_2.alt }}" loading="lazy" widt...

blocks/app-block.liquid:20: style: SpaceInsideBraces: Space missing after '{{'.
	<img src="{{ block.settings.image_2 | img_url: '1024x' }}" alt="{{ block.settings.image_2.alt }}" loading="lazy" widt...
	             ^

blocks/app-block.liquid:20: style: SpaceInsideBraces: Space missing before '}}'.
	<img src="{{ block.settings.image_2 | img_url: '1024x' }}" alt="{{ block.settings.image_2.alt }}" loading="lazy" widt...
	                     ^

blocks/app-block.liquid:27: style: SpaceInsideBraces: Space missing before '}}'.
	<img src="{{ block.settings.image_3 | img_url: '1024x'}}" alt="{{ block.settings.image_3.alt }}" loading="lazy" width...
	                                               ^

blocks/app-block.liquid:27: style: SpaceInsideBraces: Space missing after '{{'.
	<img src="{{ block.settings.image_3 | img_url: '1024x'}}" alt="{{ block.settings.image_3.alt }}" loading="lazy" width...
	             ^

blocks/app-block.liquid:27: style: SpaceInsideBraces: Space missing before '}}'.
	<img src="{{ block.settings.image_3 | img_url: '1024x'}}" alt="{{ block.settings.image_3.alt }}" loading="lazy" width...
	                                                                                                                    ^

blocks/app-block.liquid:27: style: SpaceInsideBraces: Space missing after '{{'.
	<img src="{{ block.settings.image_3 | img_url: '1024x'}}" alt="{{ block.settings.image_3.alt }}" loading="lazy" width...
	             ^

blocks/app-block.liquid:27: style: SpaceInsideBraces: Space missing before '}}'.
	<img src="{{ block.settings.image_3 | img_url: '1024x'}}" alt="{{ block.settings.image_3.alt }}" loading="lazy" width...
	                     ^

blocks/app-block.liquid:34: style: SpaceInsideBraces: Space missing after '{{'.
	<img src="{{ block.settings.image_4 | img_url: '1024x' }}" alt="{{ block.settings.image_4.alt }}" loading="lazy" widt...
	             ^

blocks/app-block.liquid:34: style: SpaceInsideBraces: Space missing before '}}'.
	<img src="{{ block.settings.image_4 | img_url: '1024x' }}" alt="{{ block.settings.image_4.alt }}" loading="lazy" widt...

blocks/app-block.liquid:34: style: SpaceInsideBraces: Space missing after '{{'.
	<img src="{{ block.settings.image_4 | img_url: '1024x' }}" alt="{{ block.settings.image_4.alt }}" loading="lazy" widt...
	             ^

blocks/app-block.liquid:34: style: SpaceInsideBraces: Space missing before '}}'.
	<img src="{{ block.settings.image_4 | img_url: '1024x' }}" alt="{{ block.settings.image_4.alt }}" loading="lazy" widt...
	                     ^

blocks/app-block.liquid:13: suggestion: DeprecatedFilter: Deprecated filter `img_url`, consider using `image_url`.
	<img src="{{ block.settings.image_1 | img_url: '1024x' }}" alt="{{ block.settings.image_1.alt }}" loading="lazy" widt...
	                                      ^^^^^^^^^^^^^^^^^

blocks/app-block.liquid:20: suggestion: DeprecatedFilter: Deprecated filter `img_url`, consider using `image_url`.
	<img src="{{ block.settings.image_2 | img_url: '1024x' }}" alt="{{ block.settings.image_2.alt }}" loading="lazy" widt...
	                                      ^^^^^^^^^^^^^^^^^

blocks/app-block.liquid:27: suggestion: DeprecatedFilter: Deprecated filter `img_url`, consider using `image_url`.
	<img src="{{ block.settings.image_3 | img_url: '1024x'}}" alt="{{ block.settings.image_3.alt }}" loading="lazy" width...
	                                      ^^^^^^^^^^^^^^^^

blocks/app-block.liquid:34: suggestion: DeprecatedFilter: Deprecated filter `img_url`, consider using `image_url`.
	<img src="{{ block.settings.image_4 | img_url: '1024x' }}" alt="{{ block.settings.image_4.alt }}" loading="lazy" widt...
	                                      ^^^^^^^^^^^^^^^^^

11 files inspected, 21 offenses detected, 21 offenses auto-correctable
➜  theme-app-extension
```