### PR TITLE
add conditional app block

### DIFF
--- a/blocks/conditional-app-block.liquid
+++ b/blocks/conditional-app-block.liquid
@@ -1,0 +1,12 @@
+<p> 
+  To learn more about Conditional App Blocks, visit the development <a rel="nofollow" href="https://shopify.dev/changelog/theme-app-extensions-now-support-conditional-app-blocks"> changelog </a>
+</p>
+{% schema %}
+  {
+    "name": "Conditional App Block",
+    "target": "section",
+    "available_if": "{{ app.metafields.sample_app.feature1 }}",
+    "settings": []
+  }
+{% endschema %}
+


### PR DESCRIPTION
We are introducing a sample app that uses `available_if` property. This block is conditionally enabled on storefronts only when the reference [app-owned metafield](https://shopify.dev/api/admin-graphql/2022-04/enums/MetafieldOwnerType#value-apipermission) has a value of true. 